### PR TITLE
feat: Elastic energy

### DIFF
--- a/src/dynamics/models/constitutive_model.rs
+++ b/src/dynamics/models/constitutive_model.rs
@@ -5,7 +5,7 @@ use crate::math::{Matrix, Real};
 pub trait ConstitutiveModel: Send + Sync {
     fn is_fluid(&self) -> bool;
 
-    fn elastic_energy_density(&self, _deformation_gradient: Matrix<Real>) -> Real {
+    fn elastic_energy_density(&self, _particle: &Particle) -> Real {
         0.0
     }
 

--- a/src/dynamics/models/constitutive_model.rs
+++ b/src/dynamics/models/constitutive_model.rs
@@ -4,6 +4,11 @@ use crate::math::{Matrix, Real};
 
 pub trait ConstitutiveModel: Send + Sync {
     fn is_fluid(&self) -> bool;
+
+    fn elastic_energy_density(&self, _deformation_gradient: Matrix<Real>) -> Real {
+        0.0
+    }
+
     fn pos_energy(&self, _particle: &Particle) -> Real {
         0.0
     }

--- a/src/dynamics/models/elasticity_corotated_linear.rs
+++ b/src/dynamics/models/elasticity_corotated_linear.rs
@@ -18,7 +18,7 @@ impl ConstitutiveModel for CorotatedLinearElasticity {
     }
 
     fn elastic_energy_density(&self, particle: &Particle) -> Real {
-        self.elastic_energy_density(particle.deformation_gradient)
+        self.elastic_energy_density(particle.deformation_gradient, particle.elastic_hardening)
     }
 
     fn pos_energy(&self, particle: &Particle) -> Real {

--- a/src/dynamics/models/elasticity_corotated_linear.rs
+++ b/src/dynamics/models/elasticity_corotated_linear.rs
@@ -17,6 +17,21 @@ impl ConstitutiveModel for CorotatedLinearElasticity {
         )
     }
 
+    // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.3
+    fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
+        let singular_values = deformation_gradient
+            .svd_unordered(false, false)
+            .singular_values;
+        let determinant: Real = singular_values.iter().product();
+
+        self.mu
+            * singular_values
+                .iter()
+                .map(|sigma| (sigma - 1.).powi(2))
+                .sum::<Real>()
+            + self.lambda / 2. * (determinant - 1.).powi(2)
+    }
+
     fn pos_energy(&self, particle: &Particle) -> Real {
         self.pos_energy(particle.deformation_gradient, particle.elastic_hardening)
     }

--- a/src/dynamics/models/elasticity_corotated_linear.rs
+++ b/src/dynamics/models/elasticity_corotated_linear.rs
@@ -17,19 +17,8 @@ impl ConstitutiveModel for CorotatedLinearElasticity {
         )
     }
 
-    // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.3
-    fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
-        let singular_values = deformation_gradient
-            .svd_unordered(false, false)
-            .singular_values;
-        let determinant: Real = singular_values.iter().product();
-
-        self.mu
-            * singular_values
-                .iter()
-                .map(|sigma| (sigma - 1.).powi(2))
-                .sum::<Real>()
-            + self.lambda / 2. * (determinant - 1.).powi(2)
+    fn elastic_energy_density(&self, particle: &Particle) -> Real {
+        self.elastic_energy_density(particle.deformation_gradient)
     }
 
     fn pos_energy(&self, particle: &Particle) -> Real {

--- a/src/dynamics/models/elasticity_neo_hookean.rs
+++ b/src/dynamics/models/elasticity_neo_hookean.rs
@@ -17,13 +17,8 @@ impl ConstitutiveModel for NeoHookeanElasticity {
         )
     }
 
-    // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.2
-    fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
-        let determinant_log = deformation_gradient.determinant().ln();
-        self.mu / 2.
-            * ((deformation_gradient.transpose() * deformation_gradient).trace() - DIM as Real)
-            - self.mu * determinant_log
-            + self.lambda / 2. * determinant_log.powi(2)
+    fn elastic_energy_density(&self, particle: &Particle) -> Real {
+        self.elastic_energy_density(particle.deformation_gradient)
     }
 
     fn pos_energy(&self, particle: &Particle) -> Real {

--- a/src/dynamics/models/elasticity_neo_hookean.rs
+++ b/src/dynamics/models/elasticity_neo_hookean.rs
@@ -18,7 +18,7 @@ impl ConstitutiveModel for NeoHookeanElasticity {
     }
 
     fn elastic_energy_density(&self, particle: &Particle) -> Real {
-        self.elastic_energy_density(particle.deformation_gradient)
+        self.elastic_energy_density(particle.deformation_gradient, particle.elastic_hardening)
     }
 
     fn pos_energy(&self, particle: &Particle) -> Real {

--- a/src/dynamics/models/elasticity_neo_hookean.rs
+++ b/src/dynamics/models/elasticity_neo_hookean.rs
@@ -18,7 +18,11 @@ impl ConstitutiveModel for NeoHookeanElasticity {
     }
 
     fn elastic_energy_density(&self, particle: &Particle) -> Real {
-        self.elastic_energy_density(particle.deformation_gradient, particle.elastic_hardening)
+        self.elastic_energy_density(
+            particle.phase,
+            particle.elastic_hardening,
+            &particle.deformation_gradient,
+        )
     }
 
     fn pos_energy(&self, particle: &Particle) -> Real {

--- a/src/dynamics/models/elasticity_neo_hookean.rs
+++ b/src/dynamics/models/elasticity_neo_hookean.rs
@@ -2,7 +2,7 @@ use crate::dynamics::models::{
     ActiveTimestepBounds, ConstitutiveModel, CoreConstitutiveModel, NeoHookeanElasticity,
 };
 use crate::dynamics::Particle;
-use crate::math::{Matrix, Real};
+use crate::math::{Matrix, Real, DIM};
 
 impl ConstitutiveModel for NeoHookeanElasticity {
     fn is_fluid(&self) -> bool {
@@ -15,6 +15,15 @@ impl ConstitutiveModel for NeoHookeanElasticity {
             particle.elastic_hardening,
             &particle.deformation_gradient,
         )
+    }
+
+    // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.2
+    fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
+        let determinant_log = deformation_gradient.determinant().ln();
+        self.mu / 2.
+            * ((deformation_gradient.transpose() * deformation_gradient).trace() - DIM as Real)
+            - self.mu * determinant_log
+            + self.lambda / 2. * determinant_log.powi(2)
     }
 
     fn pos_energy(&self, particle: &Particle) -> Real {

--- a/src_core/dynamics/models/elasticity_corotated_linear.rs
+++ b/src_core/dynamics/models/elasticity_corotated_linear.rs
@@ -101,7 +101,7 @@ impl CorotatedLinearElasticity {
     // See "Dynamic brittle fracture with eigenerosion enhanced material point method", 2.2 Elasticity degradation
     pub fn pos_energy(&self, deformation_gradient: Matrix<Real>, elastic_hardening: Real) -> Real {
         let j = deformation_gradient.determinant();
-        let mut pos_def = deformation_gradient.svd_unordered(true, true); // TODO: why compute U and V?
+        let mut pos_def = deformation_gradient.svd_unordered(false, false);
         pos_def.singular_values.apply(|e| *e = (*e - 1.0).max(0.0));
 
         let pos_dev_part = self.mu * elastic_hardening * pos_def.singular_values.norm_squared();

--- a/src_core/dynamics/models/elasticity_corotated_linear.rs
+++ b/src_core/dynamics/models/elasticity_corotated_linear.rs
@@ -76,7 +76,7 @@ impl CorotatedLinearElasticity {
 
     pub fn pos_energy(&self, deformation_gradient: Matrix<Real>, elastic_hardening: Real) -> Real {
         let j = deformation_gradient.determinant();
-        let mut pos_def = deformation_gradient.svd_unordered(true, true);
+        let mut pos_def = deformation_gradient.svd_unordered(true, true); // TODO: why compute U and V?
         pos_def.singular_values.apply(|e| *e = (*e - 1.0).max(0.0));
 
         let pos_dev_part = self.mu * elastic_hardening * pos_def.singular_values.norm_squared();

--- a/src_core/dynamics/models/elasticity_corotated_linear.rs
+++ b/src_core/dynamics/models/elasticity_corotated_linear.rs
@@ -74,6 +74,21 @@ impl CorotatedLinearElasticity {
         }
     }
 
+    // General elastic density function: https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.3 (49)
+    pub fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
+        let singular_values = deformation_gradient
+            .svd_unordered(false, false)
+            .singular_values;
+        let determinant: Real = singular_values.iter().product();
+
+        self.mu
+            * singular_values
+                .iter()
+                .map(|sigma| (sigma - 1.).powi(2))
+                .sum::<Real>()
+            + self.lambda / 2. * (determinant - 1.).powi(2)
+    }
+
     pub fn pos_energy(&self, deformation_gradient: Matrix<Real>, elastic_hardening: Real) -> Real {
         let j = deformation_gradient.determinant();
         let mut pos_def = deformation_gradient.svd_unordered(true, true); // TODO: why compute U and V?

--- a/src_core/dynamics/models/elasticity_corotated_linear.rs
+++ b/src_core/dynamics/models/elasticity_corotated_linear.rs
@@ -75,20 +75,30 @@ impl CorotatedLinearElasticity {
     }
 
     // General elastic density function: https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.3 (49)
-    pub fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
+    // With hardening: https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.5 (87)
+    pub fn elastic_energy_density(
+        &self,
+        deformation_gradient: Matrix<Real>,
+        elastic_hardening: Real,
+    ) -> Real {
         let singular_values = deformation_gradient
             .svd_unordered(false, false)
             .singular_values;
         let determinant: Real = singular_values.iter().product();
 
-        self.mu
+        let hardened_mu = self.mu * elastic_hardening;
+        let hardened_lambda = self.lambda * elastic_hardening;
+
+        hardened_mu
             * singular_values
                 .iter()
                 .map(|sigma| (sigma - 1.).powi(2))
                 .sum::<Real>()
-            + self.lambda / 2. * (determinant - 1.).powi(2)
+            + hardened_lambda / 2. * (determinant - 1.).powi(2)
     }
 
+    // Basically the same as [elastic_energy_density] but only the positive part
+    // See "Dynamic brittle fracture with eigenerosion enhanced material point method", 2.2 Elasticity degradation
     pub fn pos_energy(&self, deformation_gradient: Matrix<Real>, elastic_hardening: Real) -> Real {
         let j = deformation_gradient.determinant();
         let mut pos_def = deformation_gradient.svd_unordered(true, true); // TODO: why compute U and V?

--- a/src_core/dynamics/models/elasticity_neo_hookean.rs
+++ b/src_core/dynamics/models/elasticity_neo_hookean.rs
@@ -94,18 +94,13 @@ impl NeoHookeanElasticity {
         // aka. bulk modulus
         let kappa = 2.0 / 3.0 * hardened_mu + hardened_lambda;
 
-        let g_c = Self::phase_coeff(particle_phase);
-
         let J = F.determinant();
-
         let alpha = -1. / DIM as Real;
-
         let J_alpha = J.powf(alpha);
 
         let Psi_mu =
             |F: Matrix<Real>| hardened_mu / 2. * ((F.transpose() * F).trace() - DIM as Real);
         let Psi_mu = Psi_mu(J_alpha * F);
-
         let Psi_kappa = kappa / 2. * ((J.powi(2) - 1.) / 2. - J.ln());
 
         let (Psi_plus, Psi_minus) = if J >= 1. {
@@ -114,6 +109,7 @@ impl NeoHookeanElasticity {
             (Psi_mu, Psi_kappa)
         };
 
+        let g_c = Self::phase_coeff(particle_phase);
         g_c * Psi_plus + Psi_minus
     }
 

--- a/src_core/dynamics/models/elasticity_neo_hookean.rs
+++ b/src_core/dynamics/models/elasticity_neo_hookean.rs
@@ -76,14 +76,24 @@ impl NeoHookeanElasticity {
     }
 
     // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.2
-    pub fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
+    // With hardening: https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.5 (87)
+    pub fn elastic_energy_density(
+        &self,
+        deformation_gradient: Matrix<Real>,
+        elastic_hardening: Real,
+    ) -> Real {
         let determinant_log = deformation_gradient.determinant().ln();
-        self.mu / 2.
+
+        let hardened_mu = self.mu * elastic_hardening;
+        let hardened_lambda = self.lambda * elastic_hardening;
+
+        hardened_mu / 2.
             * ((deformation_gradient.transpose() * deformation_gradient).trace() - DIM as Real)
-            - self.mu * determinant_log
-            + self.lambda / 2. * determinant_log.powi(2)
+            - hardened_mu * determinant_log
+            + hardened_lambda / 2. * determinant_log.powi(2)
     }
 
+    // TODO: this isn't quite similar to the full density as is the case with the corotated.
     pub fn pos_energy(
         &self,
         particle_phase: Real,

--- a/src_core/dynamics/models/elasticity_neo_hookean.rs
+++ b/src_core/dynamics/models/elasticity_neo_hookean.rs
@@ -75,6 +75,15 @@ impl NeoHookeanElasticity {
         false
     }
 
+    // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.2
+    pub fn elastic_energy_density(&self, deformation_gradient: Matrix<Real>) -> Real {
+        let determinant_log = deformation_gradient.determinant().ln();
+        self.mu / 2.
+            * ((deformation_gradient.transpose() * deformation_gradient).trace() - DIM as Real)
+            - self.mu * determinant_log
+            + self.lambda / 2. * determinant_log.powi(2)
+    }
+
     pub fn pos_energy(
         &self,
         particle_phase: Real,

--- a/src_core/dynamics/models/elasticity_neo_hookean.rs
+++ b/src_core/dynamics/models/elasticity_neo_hookean.rs
@@ -130,6 +130,7 @@ impl NeoHookeanElasticity {
                 - DIM as Real);
         let volumetric_part = k / 2.0 * ((j * j - 1.0) / 2.0 - j.ln());
 
+        // TODO: shouldn't this be free of any phase dependency?
         if j < 1.0 {
             deviatoric_part * phase_coeff
         } else {

--- a/src_core/dynamics/models/elasticity_neo_hookean.rs
+++ b/src_core/dynamics/models/elasticity_neo_hookean.rs
@@ -75,7 +75,7 @@ impl NeoHookeanElasticity {
         false
     }
 
-    // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.2
+    // https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.2 (46)
     // With hardening: https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.5 (87)
     pub fn elastic_energy_density(
         &self,

--- a/src_core/dynamics/models/elasticity_neo_hookean.rs
+++ b/src_core/dynamics/models/elasticity_neo_hookean.rs
@@ -95,9 +95,11 @@ impl NeoHookeanElasticity {
         let alpha = -1. / DIM as Real;
 
         // aka. Psi_mu
-        let deviatoric_part =
-            |f: Matrix<Real>| hardened_mu / 2. * ((f.transpose() * f).trace() - DIM as Real);
-        let deviatoric_part = deviatoric_part(j.powf(alpha) * deformation_gradient);
+        let deviatoric_part = hardened_mu / 2.
+            * (((j.powf(alpha) * deformation_gradient).transpose()
+                * (j.powf(alpha) * deformation_gradient))
+                .trace()
+                - DIM as Real);
 
         // aka. Psi_kappa
         let volumetric_part = kappa / 2. * ((j.powi(2) - 1.) / 2. - j.ln());

--- a/src_core/dynamics/models/elasticity_neo_hookean.rs
+++ b/src_core/dynamics/models/elasticity_neo_hookean.rs
@@ -79,14 +79,14 @@ impl NeoHookeanElasticity {
     // General elastic density function: https://dl.acm.org/doi/pdf/10.1145/3306346.3322949#section.5 (8) and (9)
     // With degradation: https://dl.acm.org/doi/pdf/10.1145/3306346.3322949#subsection.3.2 (3)
     // With hardening: https://www.math.ucla.edu/~cffjiang/research/mpmcourse/mpmcourse.pdf#subsection.6.5 (87)
+    #[allow(non_snake_case)]
     pub fn elastic_energy_density(
         &self,
         particle_phase: Real,
         elastic_hardening: Real,
-        deformation_gradient: Matrix<Real>,
+        deformation_gradient: &Matrix<Real>,
     ) -> Real {
-        #[allow(non_snake_case)]
-        let F = &deformation_gradient;
+        let F = deformation_gradient;
 
         let hardened_mu = self.mu * elastic_hardening;
         let hardened_lambda = self.lambda * elastic_hardening;
@@ -96,24 +96,18 @@ impl NeoHookeanElasticity {
 
         let g_c = Self::phase_coeff(particle_phase);
 
-        #[allow(non_snake_case)]
         let J = F.determinant();
 
         let alpha = -1. / DIM as Real;
 
-        #[allow(non_snake_case)]
         let J_alpha = J.powf(alpha);
 
-        #[allow(non_snake_case)]
         let Psi_mu =
             |F: Matrix<Real>| hardened_mu / 2. * ((F.transpose() * F).trace() - DIM as Real);
-        #[allow(non_snake_case)]
         let Psi_mu = Psi_mu(J_alpha * F);
 
-        #[allow(non_snake_case)]
         let Psi_kappa = kappa / 2. * ((J.powi(2) - 1.) / 2. - J.ln());
 
-        #[allow(non_snake_case)]
         let (Psi_plus, Psi_minus) = if J >= 1. {
             (Psi_mu + Psi_kappa, 0.)
         } else {

--- a/src_core/utils/physics.rs
+++ b/src_core/utils/physics.rs
@@ -14,6 +14,7 @@ pub fn inv_exact(e: Real) -> Real {
 }
 
 /// Computes the Lamé parameters (lambda, mu) from the young modulus and poisson ratio.
+/// https://encyclopediaofmath.org/wiki/Lam%C3%A9_constants
 pub fn lame_lambda_mu(young_modulus: Real, poisson_ratio: Real) -> (Real, Real) {
     (
         young_modulus * poisson_ratio / ((1.0 + poisson_ratio) * (1.0 - 2.0 * poisson_ratio)),


### PR DESCRIPTION
This adds functions to compute the elastic energy density function from a given deformation gradient.

The new code is different from the existing one.
See `pos_energy`: https://github.com/dimforge/sparkl/blob/43c13a65fef40b7872ec638c866c4b42926f3354/src/dynamics/models/elasticity_corotated_linear.rs#L35-L37
We may want to refactor.