### PR TITLE
bug: Particle Model Serialization

### DIFF
--- a/src/dynamics/particle_model.rs
+++ b/src/dynamics/particle_model.rs
@@ -2,6 +2,8 @@ use crate::dynamics::models::{ConstitutiveModel, FailureModel, PlasticModel};
 use rapier::data::{Arena, Index};
 use std::sync::Arc;
 
+use super::models::ExternalModel;
+
 #[cfg(feature = "serde-serialize")]
 use {
     crate::dynamics::models::{CoreConstitutiveModel, CoreFailureModel, CorePlasticModel},
@@ -53,7 +55,9 @@ impl From<TypedData> for ParticleModel {
             CoreConstitutiveModel::CorotatedLinearElasticity(m) => {
                 Arc::new(m) as Arc<dyn ConstitutiveModel>
             }
-            CoreConstitutiveModel::Custom(_) => todo!(),
+            CoreConstitutiveModel::Custom(index) => {
+                Arc::new(ExternalModel(index)) as Arc<dyn ConstitutiveModel>
+            }
         };
         let plastic_model = value.plastic_model.map(|data| match data {
             CorePlasticModel::Snow(m) => Arc::new(m) as Arc<dyn PlasticModel>,


### PR DESCRIPTION
There is a bug in our serialization code:

The type for serialization was `(Option<A>, Option<B>, Option<C>)`
But for deserialization we used `(A, Option<B>, Option<C>)`

This PR adds a type used in both directions, which fixes this problem and makes it easier to verify.

In addition, the PR allows for (de)serialization of external models.
For now only constitutive models, we may need further external model types later on.