### PR TITLE
chore: bump patch version 0.3.1 to 0.3.2

### DIFF
--- a/crates-ptx/gen-ptx/Cargo.toml
+++ b/crates-ptx/gen-ptx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "gen-ptx"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl3d"

--- a/crates-ptx/sparkl2d-kernels-ptx/Cargo.toml
+++ b/crates-ptx/sparkl2d-kernels-ptx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl2d-kernels-ptx"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl2d"

--- a/crates-ptx/sparkl3d-kernels-ptx/Cargo.toml
+++ b/crates-ptx/sparkl3d-kernels-ptx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl3d-kernels-ptx"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl3d"

--- a/crates/sparkl2d-core/Cargo.toml
+++ b/crates/sparkl2d-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl2d-core"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl2d"

--- a/crates/sparkl2d-kernels/Cargo.toml
+++ b/crates/sparkl2d-kernels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl2d-kernels"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl2d"

--- a/crates/sparkl2d/Cargo.toml
+++ b/crates/sparkl2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl2d"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl2d"

--- a/crates/sparkl3d-core/Cargo.toml
+++ b/crates/sparkl3d-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl3d-core"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl3d"

--- a/crates/sparkl3d-kernels/Cargo.toml
+++ b/crates/sparkl3d-kernels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl3d-kernels"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl3d"

--- a/crates/sparkl3d/Cargo.toml
+++ b/crates/sparkl3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sparkl3d"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl3d"


### PR DESCRIPTION
This includes the changes from
https://github.com/dimforge/sparkl/pull/10
and
https://github.com/dimforge/sparkl/pull/19