### PR TITLE
Update to bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,25 @@
 [workspace]
-members = [ "crates/sparkl3d-core", "crates/sparkl3d-kernels", "crates/sparkl2d", "crates/sparkl2d-core", "crates/sparkl2d-kernels", "examples2d",
-            "crates/sparkl3d", "examples3d" ]
+members = [
+    "crates/sparkl3d-core",
+    "crates/sparkl3d-kernels",
+    "crates/sparkl2d",
+    "crates/sparkl2d-core",
+    "crates/sparkl2d-kernels",
+    "examples2d",
+    "crates/sparkl3d",
+    "examples3d",
+]
 resolver = "2"
 
 [patch.crates-io]
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
+rapier2d = { path = "../rapier/crates/rapier2d" }
+rapier3d = { path = "../rapier/crates/rapier3d" }
 #rapier_testbed2d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
 #rapier_testbed3d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
+rapier_testbed2d = { path = "../rapier/crates/rapier_testbed2d" }
+rapier_testbed3d = { path = "../rapier/crates/rapier_testbed3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra" }
 #simba = { git = "https://github.com/dimforge/simba" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ resolver = "2"
 [patch.crates-io]
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
-rapier2d = { path = "../rapier/crates/rapier2d" }
-rapier3d = { path = "../rapier/crates/rapier3d" }
+#rapier2d = { path = "../rapier/crates/rapier2d" }
+#rapier3d = { path = "../rapier/crates/rapier3d" }
 #rapier_testbed2d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
 #rapier_testbed3d = { git = "https://github.com/dimforge/rapier", branch = "testbed-init-app" }
-rapier_testbed2d = { path = "../rapier/crates/rapier_testbed2d" }
-rapier_testbed3d = { path = "../rapier/crates/rapier_testbed3d" }
+#rapier_testbed2d = { path = "../rapier/crates/rapier_testbed2d" }
+#rapier_testbed3d = { path = "../rapier/crates/rapier_testbed3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra" }
 #simba = { git = "https://github.com/dimforge/simba" }
 

--- a/crates/sparkl2d/Cargo.toml
+++ b/crates/sparkl2d/Cargo.toml
@@ -1,14 +1,20 @@
 [package]
-name    = "sparkl2d"
+name = "sparkl2d"
 version = "0.4.0"
-authors = [ "Sébastien Crozet <developer@crozet.re>" ]
+authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl2d"
 homepage = "http://sparkl.rs"
 repository = "https://github.com/dimforge/sparkl"
 readme = "README.md"
-categories = [ "science", "game-development", "mathematics", "simulation", "wasm"]
-keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
+categories = [
+    "science",
+    "game-development",
+    "mathematics",
+    "simulation",
+    "wasm",
+]
+keywords = ["physics", "dynamics", "rigid", "real-time", "joints"]
 license = "Apache-2.0"
 edition = "2018"
 
@@ -16,31 +22,35 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = [ "dim2", "f32" ]
+default = ["dim2", "f32"]
 dim2 = []
 f32 = []
-cuda = [ "cust", "sparkl2d-kernels" ]
+cuda = ["cust", "sparkl2d-kernels"]
 
-serde-serialize = [ "serde", "nalgebra/serde-serialize", "parry2d/serde-serialize", "rapier2d/serde-serialize",
-                    "sparkl2d-core/serde-serialize"]
+serde-serialize = [
+    "serde",
+    "nalgebra/serde-serialize",
+    "parry2d/serde-serialize",
+    "rapier2d/serde-serialize",
+    "sparkl2d-core/serde-serialize",
+]
 
 # Third-party integration.
-rapier-testbed = [ "rapier_testbed2d", "graphics", "itertools" ]
-rapier-harness = [ "rapier-testbed" ]
-graphics = [ "bevy", "bevy_egui", "bevy_ecs" ]
+rapier-testbed = ["rapier_testbed2d", "graphics", "itertools"]
+rapier-harness = ["rapier-testbed"]
+graphics = ["bevy", "bevy_egui", "bevy_ecs"]
 
 [lib]
 path = "../../src/lib.rs"
-required-features = [ "dim2", "f32" ]
-
+required-features = ["dim2", "f32"]
 
 
 [dependencies]
 sparkl2d-core = { version = "0.4", path = "../sparkl2d-core" }
 nalgebra = "0.32"
 parry2d = "0.13"
-rapier2d = { version = "0.17.2", git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
-instant = { version = "0.1", features = [ "now" ] }
+rapier2d = { version = "0.18" }
+instant = { version = "0.1", features = ["now"] }
 bitflags = "1"
 anyhow = "1"
 log = "0.4"
@@ -48,7 +58,7 @@ log = "0.4"
 oorandom = "11" # TODO: remove this, only for testing.
 
 # Serialization
-serde = { version = "1.0", optional = true, features = [ "derive" ]}
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # Parallelism
 rayon = "1"
@@ -59,9 +69,9 @@ memmap2 = "0.5"
 bytemuck = "1"
 
 # Third-party integration
-rapier_testbed2d = { version = "0.17.0", optional = true , git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
-bevy_egui = { version = "0.22", optional = true, features = [ "immutable_ctx" ] }
-bevy_ecs = { version = "0.11", optional = true }
+rapier_testbed2d = { version = "0.18.0", optional = true }
+bevy_egui = { version = "0.23", optional = true, features = ["immutable_ctx"] }
+bevy_ecs = { version = "0.12", optional = true }
 itertools = { version = "0.10", optional = true }
 
 # CUDA
@@ -69,7 +79,14 @@ cust = { version = "0.3", optional = true }
 sparkl2d-kernels = { version = "0.4", optional = true, path = "../sparkl2d-kernels" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.11", default-features = false, features = ["bevy_winit", "bevy_pbr", "bevy_sprite", "bevy_core_pipeline", "bevy_render", "x11"], optional = true }
+bevy = { version = "0.12", default-features = false, features = [
+    "bevy_winit",
+    "bevy_pbr",
+    "bevy_sprite",
+    "bevy_core_pipeline",
+    "bevy_render",
+    "x11",
+], optional = true }
 
 # Dependencies for WASM only.
 #[target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/sparkl3d/Cargo.toml
+++ b/crates/sparkl3d/Cargo.toml
@@ -71,7 +71,7 @@ bytemuck = "1"
 # Third-party integration
 rapier_testbed3d = { version = "0.18", optional = true }
 
-bevy_egui = { version = "0.22", optional = true, features = ["immutable_ctx"] }
+bevy_egui = { version = "0.23", optional = true, features = ["immutable_ctx"] }
 bevy_ecs = { version = "0.12", optional = true }
 itertools = { version = "0.10", optional = true }
 

--- a/crates/sparkl3d/Cargo.toml
+++ b/crates/sparkl3d/Cargo.toml
@@ -1,14 +1,20 @@
 [package]
-name    = "sparkl3d"
+name = "sparkl3d"
 version = "0.4.0"
-authors = [ "Sébastien Crozet <developer@crozet.re>" ]
+authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/sparkl3d"
 homepage = "http://sparkl.rs"
 repository = "https://github.com/dimforge/sparkl"
 readme = "README.md"
-categories = [ "science", "game-development", "mathematics", "simulation", "wasm"]
-keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
+categories = [
+    "science",
+    "game-development",
+    "mathematics",
+    "simulation",
+    "wasm",
+]
+keywords = ["physics", "dynamics", "rigid", "real-time", "joints"]
 license = "Apache-2.0"
 edition = "2018"
 
@@ -16,31 +22,35 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = [ "dim3", "f32" ]
+default = ["dim3", "f32"]
 dim3 = []
 f32 = []
-cuda = [ "cust", "sparkl3d-kernels" ]
+cuda = ["cust", "sparkl3d-kernels"]
 
-serde-serialize = [ "serde", "nalgebra/serde-serialize", "parry3d/serde-serialize", "rapier3d/serde-serialize",
-                    "sparkl3d-core/serde-serialize" ]
+serde-serialize = [
+    "serde",
+    "nalgebra/serde-serialize",
+    "parry3d/serde-serialize",
+    "rapier3d/serde-serialize",
+    "sparkl3d-core/serde-serialize",
+]
 
 # Third-party integration.
-rapier-testbed = [ "rapier_testbed3d", "graphics", "itertools" ]
-rapier-harness = [ "rapier-testbed" ]
-graphics = [ "bevy", "bevy_egui", "bevy_ecs" ]
+rapier-testbed = ["rapier_testbed3d", "graphics", "itertools"]
+rapier-harness = ["rapier-testbed"]
+graphics = ["bevy", "bevy_egui", "bevy_ecs"]
 
 [lib]
 path = "../../src/lib.rs"
-required-features = [ "dim3", "f32" ]
-
+required-features = ["dim3", "f32"]
 
 
 [dependencies]
 sparkl3d-core = { version = "0.4", path = "../sparkl3d-core" }
 nalgebra = "0.32"
 parry3d = "0.13"
-rapier3d = { version = "0.17.2", git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
-instant = { version = "0.1", features = [ "now" ] }
+rapier3d = { version = "0.18" }
+instant = { version = "0.1", features = ["now"] }
 bitflags = "1"
 anyhow = "1"
 log = "0.4"
@@ -48,7 +58,7 @@ log = "0.4"
 oorandom = "11" # TODO: remove this, only for testing.
 
 # Serialization
-serde = { version = "1.0", optional = true, features = [ "derive" ]}
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # Parallelism
 rayon = "1"
@@ -59,10 +69,10 @@ memmap2 = "0.5"
 bytemuck = "1"
 
 # Third-party integration
-rapier_testbed3d = { version = "0.17.0", optional = true, git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
+rapier_testbed3d = { version = "0.18", optional = true }
 
-bevy_egui = { version = "0.22", optional = true, features = [ "immutable_ctx" ] }
-bevy_ecs = { version = "0.11", optional = true }
+bevy_egui = { version = "0.22", optional = true, features = ["immutable_ctx"] }
+bevy_ecs = { version = "0.12", optional = true }
 itertools = { version = "0.10", optional = true }
 
 # CUDA
@@ -70,7 +80,11 @@ cust = { version = "0.3", optional = true }
 sparkl3d-kernels = { version = "0.4", optional = true, path = "../sparkl3d-kernels" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.11", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
+bevy = { version = "0.12", default-features = false, features = [
+    "bevy_winit",
+    "bevy_render",
+    "x11",
+], optional = true }
 
 # Dependencies for WASM only.
 #[target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name    = "sparkl-examples-2d"
+name = "sparkl-examples-2d"
 version = "0.2.0"
-authors = [ "Sébastien Crozet <developer@crozet.re>" ]
+authors = ["Sébastien Crozet <developer@crozet.re>"]
 edition = "2018"
 default-run = "examples2d"
 
 [features]
-cuda = [ "sparkl2d/cuda" ]
+cuda = ["sparkl2d/cuda"]
 
 [dependencies]
-Inflector  = "0.11"
+Inflector = "0.11"
 nalgebra = "0.32"
-rapier_testbed2d = { version = "0.17.0", git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
-rapier2d = { version = "0.17.2", git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
+rapier_testbed2d = { version = "0.18.0" }
+rapier2d = { version = "0.18" }
 oorandom = "11"
-serde = { version = "1", features = [ "derive" ]}
-serde_json = { version = "1", features = [ "preserve_order" ] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
 bincode = "1"
-indexmap = { version = "1", features = [ "serde" ] }
+indexmap = { version = "1", features = ["serde"] }
 uuid = "1"
 env_logger = "0.10"
 log = "0.4"
 
 [dependencies.sparkl2d]
 path = "../crates/sparkl2d"
-features = [ "rapier-testbed", "serde-serialize" ]
+features = ["rapier-testbed", "serde-serialize"]
 
 [[bin]]
 name = "examples2d"

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name    = "sparkl-examples-3d"
+name = "sparkl-examples-3d"
 version = "0.2.0"
-authors = [ "Sébastien Crozet <developer@crozet.re>" ]
+authors = ["Sébastien Crozet <developer@crozet.re>"]
 edition = "2018"
 default-run = "examples3d"
 
 [features]
-cuda = [ "sparkl3d/cuda" ]
+cuda = ["sparkl3d/cuda"]
 
 [dependencies]
-Inflector  = "0.11"
+Inflector = "0.11"
 nalgebra = "0.32"
-rapier_testbed3d = { version = "0.17.0", git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
-rapier3d = { version = "0.17.2", git = "https://github.com/dimforge/rapier.git", rev = "e9ea2ca10b3058a6ac2d7f4b79d351ef18ad3c06" }
+rapier_testbed3d = { version = "0.18" }
+rapier3d = { version = "0.18" }
 oorandom = "11"
-serde = { version = "1", features = [ "derive" ]}
-serde_json = { version = "1", features = [ "preserve_order" ] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
 bincode = "1"
-indexmap = { version = "1", features = [ "serde" ] }
+indexmap = { version = "1", features = ["serde"] }
 uuid = "1"
 env_logger = "0.10"
 log = "0.4"
 
 [dependencies.sparkl3d]
 path = "../crates/sparkl3d"
-features = [ "rapier-testbed", "serde-serialize" ]
+features = ["rapier-testbed", "serde-serialize"]
 
 [[bin]]
 name = "examples3d"

--- a/src/third_party/rapier/point_cloud_render.rs
+++ b/src/third_party/rapier/point_cloud_render.rs
@@ -1,19 +1,14 @@
-use std::{any::TypeId, fs::read_to_string};
+use std::fs::read_to_string;
 
 use bevy::{
-    asset::UntypedAssetId,
     core_pipeline::core_3d::Opaque3d,
     ecs::system::{lifetimeless::*, SystemParamItem},
     math::prelude::*,
-    pbr::{
-        MeshPipeline, MeshPipelineKey, MeshTransforms, MeshUniform, SetMeshBindGroup,
-        SetMeshViewBindGroup,
-    },
+    pbr::{MeshPipeline, MeshPipelineKey, MeshTransforms, SetMeshBindGroup, SetMeshViewBindGroup},
     prelude::*,
-    reflect::TypeUuid,
     render::{
         extract_component::{ExtractComponent, ExtractComponentPlugin},
-        mesh::{GpuBufferInfo, GpuMesh, MeshVertexBufferLayout},
+        mesh::{GpuBufferInfo, MeshVertexBufferLayout},
         render_asset::RenderAssets,
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
@@ -24,7 +19,6 @@ use bevy::{
         view::{ExtractedView, Msaa},
         Render, RenderApp, RenderSet,
     },
-    utils::Uuid,
 };
 use bytemuck::{Pod, Zeroable};
 
@@ -109,7 +103,6 @@ fn queue_custom(
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
 
     for (view, mut transparent_phase) in views.iter_mut() {
-        let view_matrix = view.transform.compute_matrix();
         let rangefinder = view.rangefinder3d();
         for (entity, mesh_transforms, mesh_handle) in material_meshes.iter() {
             if let Some(mesh) = meshes.get(mesh_handle) {

--- a/src/third_party/rapier/point_cloud_render.rs
+++ b/src/third_party/rapier/point_cloud_render.rs
@@ -122,7 +122,6 @@ fn queue_custom(
                     entity,
                     pipeline,
                     draw_function: draw_custom,
-                    // NOTE: TB: See https://github.com/bevyengine/bevy/blob/5f061ea0086c170853e8a9eb8f1c2e6ece414ef3/examples/shader/shader_instancing.rs#L155
                     distance: rangefinder
                         .distance_translation(&mesh_transforms.transform.translation),
                     batch_range: 0..1,

--- a/src/third_party/rapier/shaders/instancing3d.wgsl
+++ b/src/third_party/rapier/shaders/instancing3d.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::mesh_functions::{get_model_matrix, mesh_position_local_to_clip}
+#import bevy_pbr::mesh_functions::mesh_position_local_to_clip
 
 struct Vertex {
     @location(0) position: vec3<f32>,
@@ -14,17 +14,20 @@ struct VertexOutput {
     @location(0) color: vec4<f32>,
 };
 
+const identity: mat4x4<f32> = mat4x4<f32>(
+    1.0, 0.0, 0.0, 0.0,
+    0.0, 1.0, 0.0, 0.0,
+    0.0, 0.0, 1.0, 0.0,
+    0.0, 0.0, 0.0, 1.0
+);
+    
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
     let position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
 
     var out: VertexOutput;
-    // NOTE: Passing 0 as the instance_index to get_model_matrix() is a hack
-    // for this example as the instance_index builtin would map to the wrong
-    // index in the Mesh array. This index could be passed in via another
-    // uniform instead but it's unnecessary for the example.
     out.clip_position = mesh_position_local_to_clip(
-        get_model_matrix(0u),
+        identity,
         vec4<f32>(position, 1.0)
     );
     out.color = vertex.i_color;

--- a/src/third_party/rapier/shaders/instancing3d.wgsl
+++ b/src/third_party/rapier/shaders/instancing3d.wgsl
@@ -1,8 +1,4 @@
-#import bevy_pbr::mesh_view_bindings view
-#import bevy_pbr::mesh_types Mesh
-
-@group(1) @binding(0)
-var<uniform> mesh: Mesh;
+#import bevy_pbr::mesh_functions::{get_model_matrix, mesh_position_local_to_clip}
 
 struct Vertex {
     @location(0) position: vec3<f32>,
@@ -21,10 +17,16 @@ struct VertexOutput {
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
     let position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
-    let world_position = mesh.model * vec4<f32>(position, 1.0);
 
     var out: VertexOutput;
-    out.clip_position = view.view_proj * world_position;
+    // NOTE: Passing 0 as the instance_index to get_model_matrix() is a hack
+    // for this example as the instance_index builtin would map to the wrong
+    // index in the Mesh array. This index could be passed in via another
+    // uniform instead but it's unnecessary for the example.
+    out.clip_position = mesh_position_local_to_clip(
+        get_model_matrix(0u),
+        vec4<f32>(position, 1.0)
+    );
     out.color = vertex.i_color;
     return out;
 }

--- a/src/third_party/rapier/testbed_plugin.rs
+++ b/src/third_party/rapier/testbed_plugin.rs
@@ -396,8 +396,7 @@ impl TestbedPlugin for MpmTestbedPlugin {
                     Transform::from_xyz(0.0, 0.0, 0.0),
                     GlobalTransform::default(),
                     ParticleInstanceMaterialData(vec![]),
-                    Visibility::default(),
-                    ComputedVisibility::default(),
+                    VisibilityBundle::default(),
                 ))
                 .id();
 


### PR DESCRIPTION
The main objective is to update to bevy 0.14.

I did try to make the full jump, but 99+ errors were overwhelming, so I'm splitting the work for each bevy version: this PR focuses on bevy 0.12, I'll list good references here and in comments:

- migration guide: https://bevyengine.org/learn/migration-guides/0-11-to-0-12
- instancing shader example from bevy, checking out specific bevy version is useful: https://github.com/bevyengine/bevy/blob/main/examples/shader/shader_instancing.rs#L155

<details><summary>Details</summary>
<p>

There was a bug with the 3d rendering as of 95d22b7fc6be2e4b21116d04b79601f00a6ab1c8: ; see https://github.com/dimforge/sparkl/pull/23#discussion_r1737057483 for investigation thread.

[Screencast from 08-29-2024 12:05:00 PM.webm](https://github.com/user-attachments/assets/a62848ae-610a-4793-baeb-0b2cdc3ad374)

Solved by passing the identity function rather than incorrect model matrix.

</p>
</details> 


